### PR TITLE
Add leave session functionality

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -20,5 +20,4 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm ci # Warnings are treated as errors
     - run: npm test
-    - run: testcafe chrome "testitiedosto.js"
     - run: npm run build --if-present

--- a/server.js
+++ b/server.js
@@ -53,6 +53,12 @@ io.sockets.on("connection", (socket) => {
     socket.to(broadcaster).emit("disconnectPeer", socket.id);
   });
 
+  socket.on("streamerDisconnect", () => {
+    console.log("Streamer ended session: ", socket.id);
+    socket.to(broadcaster).emit("disconnectPeer", socket.id);
+    io.emit("streamerTimeouted");
+  });
+
   socket.on("streamerTimeout", () => {
     console.log(
       "Streamer closed the window, waiting for 10 minutes to recover"

--- a/src/Components/LeaveSessionButton.js
+++ b/src/Components/LeaveSessionButton.js
@@ -1,15 +1,18 @@
 import React from 'react'
 import {Link } from 'react-router-dom'
+import { socket } from "../Services/socket"
 
 
 class LeaveSessionButton extends React.Component {
     handleClick = () => {
-
+      if(this.props.isBroadcaster == true){
+        socket.emit("streamerDisconnect");
+      }
   };
   
   render() {
     return (
-         <Link to="/home"><button id="leaveSessionButton">Leave session</button></Link> 
+         <Link to="/home"><button id="leaveSessionButton" onClick={this.handleClick}>Leave session</button></Link> 
     );
   }
 }

--- a/src/Containers/BroadcastContainer.js
+++ b/src/Containers/BroadcastContainer.js
@@ -260,7 +260,7 @@ export default function BroadcastContainer(props) {
                 ref={selfVideoElement}
             />
 
-            <ParticipantsContainer participants={participants} peerStreams={peerStreams} selectParticipant={selectParticipant}/>
+            <ParticipantsContainer participants={participants} peerStreams={peerStreams} selectParticipant={selectParticipant} isBroadcaster={true}/>
                   
 
         </div>

--- a/src/Containers/ParticipantsContainer.js
+++ b/src/Containers/ParticipantsContainer.js
@@ -59,7 +59,7 @@ export default function ParticipantsContainer(props) {
                 <CameraOffButton />
                 <CameraOnButton />
                 <InviteLinkButton />
-                <LeaveSessionButton />
+                <LeaveSessionButton isBroadcaster={props.isBroadcaster} />
             </div>           
             <div className="thumbnails">
                 {


### PR DESCRIPTION
Adds leave button prop on broadcastContainer. 

If broadcaster stops streaming, disconnect and refresh viewers (would it be better to redirect to the home page actually?).